### PR TITLE
Add dbmate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ CICD is configured to automatically recognize new *PyPI* releases by looking for
 - `pip install rclone-bin`: [pybin version](https://github.com/justin-yan/pybin/tree/main/src/rclone), [upstream source](https://github.com/rclone/rclone)
 - `pip install scc-bin`: [pybin version](https://github.com/justin-yan/pybin/tree/main/src/scc), [upstream source](https://github.com/boyter/scc)
 - `pip install usql-bin`: [pybin version](https://github.com/justin-yan/pybin/tree/main/src/usql), [upstream source](https://github.com/xo/usql)
+- `pip install dbmate-bin`: [pybin version](https://github.com/justin-yan/pybin/tree/main/src/dbmate), [upstream source](https://github.com/amacneil/dbmate)

--- a/src/dbmate/build.py
+++ b/src/dbmate/build.py
@@ -12,7 +12,7 @@ TARGET_TAG = {
     'macos-amd64': 'macosx_10_9_x86_64',
     'linux-amd64': 'manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64',
 }
-URL_TAG = {f"https://github.com/amacneil/dbmate/releases/download/{VERSION}/{NAME}-{target}": tag for target, tag in TARGET_TAG.items()}
+URL_TAG = {f"https://github.com/amacneil/dbmate/releases/download/v{VERSION}/{NAME}-{target}": tag for target, tag in TARGET_TAG.items()}
 
 
 if __name__ == "__main__":

--- a/src/dbmate/build.py
+++ b/src/dbmate/build.py
@@ -2,7 +2,7 @@ from ..buildlib import build_wheels
 
 NAME = 'dbmate'
 VERSION = '2.17.0'
-PYPI_VERSION = '2.17.0'
+PYPI_VERSION = '2.17.0a1'
 SUMMARY = "A thin wrapper to distribute https://github.com/amacneil/dbmate via pip."
 LICENSE = "MIT"
 

--- a/src/dbmate/build.py
+++ b/src/dbmate/build.py
@@ -1,0 +1,25 @@
+from ..buildlib import build_wheels
+
+NAME = 'dbmate'
+VERSION = '2.17.0'
+PYPI_VERSION = '2.17.0'
+SUMMARY = "A thin wrapper to distribute https://github.com/amacneil/dbmate via pip."
+LICENSE = "MIT"
+
+TARGET_TAG = {
+    'macos-arm64': 'macosx_11_0_arm64',
+    'linux-arm64': 'manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64',
+    'macos-amd64': 'macosx_10_9_x86_64',
+    'linux-amd64': 'manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64',
+}
+URL_TAG = {f"https://github.com/amacneil/dbmate/releases/download/{VERSION}/{NAME}-{target}": tag for target, tag in TARGET_TAG.items()}
+
+
+if __name__ == "__main__":
+    build_wheels(
+        NAME,
+        PYPI_VERSION,
+        URL_TAG,
+        SUMMARY,
+        LICENSE,
+        )


### PR DESCRIPTION
I'm not sure if I did it right but I tried to add this https://github.com/amacneil/dbmate, nice project imo.

I noticed there was no windows tag for other projects so I left the option out, is there a specific reason why no tool includes it ?

```python
TARGET_TAG = {
    'macos-arm64': 'macosx_11_0_arm64',
    'linux-arm64': 'manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64',
    'macos-amd64': 'macosx_10_9_x86_64',
    'linux-amd64': 'manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64',
    'windows-amd64.exe': 'win_amd64',
}
```