### PR TITLE
Use fixed version of cicd-py image

### DIFF
--- a/.github/workflows/register.yaml
+++ b/.github/workflows/register.yaml
@@ -7,7 +7,7 @@ jobs:
   register:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/iomorphic/image/cicd-py:latest
+      image: ghcr.io/iomorphic/image/cicd-py:0.0.2
       volumes:
         - /usr/bin/docker:/usr/bin/docker
     steps:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -8,7 +8,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/iomorphic/image/cicd-py:latest
+      image: ghcr.io/iomorphic/image/cicd-py:0.0.2
       volumes:
         - /usr/bin/docker:/usr/bin/docker
     steps:


### PR DESCRIPTION
The cicd-py image was updated to use `uv` as the main python toolchain, but this project hasn't been migrated to handle that yet