### PR TITLE
Current registration setup doesn't support adding new wheels to existing release

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -30,7 +30,7 @@ sync FORCE="noforce":
     git diff --name-only HEAD^1 HEAD -G"^pypi_version:" "tools/*.yaml" | xargs -n1 basename | sed 's/\.yaml$//' | xargs -I {} sh -c 'just _register {}'
 
 @_register APP_NAME: init (build APP_NAME)
-    uv run --no-sync twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD {{APP_NAME}}-dist/*
+    uv run --no-sync twine upload --skip-existing -u $PYPI_USERNAME -p $PYPI_PASSWORD {{APP_NAME}}-dist/*
 
 @update: init
     uv run --no-sync python scripts/update.py {{justfile_directory()}}/tools

--- a/tools/rclone.yaml
+++ b/tools/rclone.yaml
@@ -1,7 +1,7 @@
 name: rclone
 upstream_repo: https://github.com/rclone/rclone
 version: "1.73.5"
-pypi_version: "1.73.5"
+pypi_version: "1.73.5a1"
 license: MIT
 
 url_template: "{repo}/releases/download/v{version}/{name}-v{version}-{target}.zip"


### PR DESCRIPTION
Try this out with --skip-existing,
also create an alpha release for the windows rclone dist