### PR TITLE
Add support for oxfmt

### DIFF
--- a/tools/oxfmt.yaml
+++ b/tools/oxfmt.yaml
@@ -1,0 +1,14 @@
+name: oxfmt
+upstream_repo: https://github.com/oxc-project/oxc
+version: "1.66.0"
+pypi_version: "1.66.0"
+license: MIT
+
+url_template: "{repo}/releases/download/apps_v{version}/{name}-{target}"
+
+targets:
+  aarch64-apple-darwin.tar.gz: macos_arm
+  x86_64-apple-darwin.tar.gz: macos_x86
+  armv7-unknown-linux-gnueabihf.tar.gz: linux_arm
+  x86_64-unknown-linux-gnu.tar.gz: linux_x86
+  x86_64-pc-windows-msvc.zip: win_x86


### PR DESCRIPTION
The built packages work on macos and windows. I haven't tested the other platforms.

I'm not sure the pypi version will get updated properly because the github release tag and the oxfmt version are different. I ran update.py as a test and it only updated the `version` field and not the `pypi_version` field.

@justin-yan Should `pypi_version` instead match `version` for this application?