### PR TITLE
Switch the justfile build process over to the syncrule setup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -30,10 +30,10 @@ sync FORCE="noforce":
 
 @build APP_NAME: init
     echo "Building {{APP_NAME}}"
-    uv run --no-sync python scripts/build_from_yaml.py tools/{{APP_NAME}}.yaml
+    uv run --no-sync python scripts/build_from_yaml.py rules/{{APP_NAME}}.yaml
 
 @register:
-    git diff --name-only HEAD^1 HEAD -G"^pypi_version:" "tools/*.yaml" | xargs -n1 basename | sed 's/\.yaml$//' | xargs -I {} sh -c 'just _register {}'
+    git diff --name-only HEAD^1 HEAD -G"^    version:" "rules/*.yaml" | xargs -n1 basename | sed 's/\.yaml$//' | xargs -I {} sh -c 'just _register {}'
 
 @_register APP_NAME: init (build APP_NAME)
     uv publish --trusted-publishing always {{APP_NAME}}-dist/*
@@ -75,7 +75,7 @@ testmark MARK="" TARGET=TEST_FOLDER:
 @validate: init
     #!/usr/bin/env bash
     set -ex
-    for yaml_file in {{justfile_directory()}}/tools/*.yaml; do
+    for yaml_file in {{justfile_directory()}}/rules/*.yaml; do
         app_name=$(basename "$yaml_file" .yaml)
         echo "Validating $app_name..."
         just build "$app_name"

--- a/scripts/build_from_yaml.py
+++ b/scripts/build_from_yaml.py
@@ -1,23 +1,21 @@
 import sys
 from pathlib import Path
 
-from pybin.config import load_config
-from pybin.buildlib import build_wheels_from_config
+from pybin.sync import sync
 
 
 def main():
     if len(sys.argv) != 2:
-        print("Usage: python -m pybin.build_from_yaml <config.yaml>", file=sys.stderr)
+        print("Usage: python scripts/build_from_yaml.py <rule.yaml>", file=sys.stderr)
         sys.exit(1)
 
-    config_path = Path(sys.argv[1])
-    if not config_path.exists():
-        print(f"Config file not found: {config_path}", file=sys.stderr)
+    rule_path = Path(sys.argv[1])
+    if not rule_path.exists():
+        print(f"Rule file not found: {rule_path}", file=sys.stderr)
         sys.exit(1)
 
-    config = load_config(config_path)
-    print(f"Building {config.name} v{config.pypi_version} from {config_path}")
-    build_wheels_from_config(config)
+    print(f"Building from {rule_path}")
+    sync(rule_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previous PR validated via compatibility integration test that previous buildlib and syncrule wheels match byte for byte.

This cuts over to the new rules yaml + syncrule setup.

Once fully cut over, will delete old buildlib, and migrate justfile validate into integration testing setup.